### PR TITLE
Removing jekyll from run dependencies because it breaks rosdep

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -29,7 +29,6 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>opencv2</run_depend>
   <run_depend>nodejs</run_depend>
-  <run_depend>jekyll</run_depend>
 
   <buildtool_depend>ruby1.9.3</buildtool_depend>
   <buildtool_depend>nodejs</buildtool_depend>


### PR DESCRIPTION
`gem` is not supported by rosdep which is why `jekyll` cannot be installed that way and breaks `rosdep install`.
Fixing #2
