### PR TITLE
added jekyll

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -29,6 +29,7 @@
   <run_depend>sensor_msgs</run_depend>
   <run_depend>opencv2</run_depend>
   <run_depend>nodejs</run_depend>
+  <run_depend>rubygem-jekyll</run_depend>
 
   <buildtool_depend>ruby1.9.3</buildtool_depend>
   <buildtool_depend>nodejs</buildtool_depend>


### PR DESCRIPTION
I have managed to package up jekyll using [this method](https://gist.github.com/marc-hanheide/4ebea62ada0883ed84eb) and made them available on our own repository: 

```
precise|main|amd64: rubygem-blankslate 2.1.2.4                                                                                                          
precise|main|amd64: rubygem-celluloid 0.16.0                                                                                                            
precise|main|amd64: rubygem-classifier-reborn 2.0.1                                                                                                     
precise|main|amd64: rubygem-coffee-script 2.3.0                                                                                                         
precise|main|amd64: rubygem-coffee-script-source 1.8.0                                                                                                  
precise|main|amd64: rubygem-colorator 0.1.0                                                                                                             
precise|main|amd64: rubygem-execjs 2.2.2                                                                                                                
precise|main|amd64: rubygem-fast-stemmer 1.0.2                                                                                                          
precise|main|amd64: rubygem-ffi 1.9.6                                                                                                                   
precise|main|amd64: rubygem-hitimes 1.2.2                                                                                                               
precise|main|amd64: rubygem-jekyll 2.4.0                                                                                                                
precise|main|amd64: rubygem-jekyll-coffeescript 1.0.1                                                                                                   
precise|main|amd64: rubygem-jekyll-gist 1.1.0                                                                                                           
precise|main|amd64: rubygem-jekyll-paginate 1.1.0                                                                                                       
precise|main|amd64: rubygem-jekyll-sass-converter 1.2.1                                                                                                 
precise|main|amd64: rubygem-jekyll-watch 1.1.1                                                                                                          
precise|main|amd64: rubygem-kramdown 1.5.0                                                                                                              
precise|main|amd64: rubygem-liquid 2.6.1                                                                                                                
precise|main|amd64: rubygem-listen 2.7.11                                                                                                               
precise|main|amd64: rubygem-mercenary 0.3.4                                                                                                             
precise|main|amd64: rubygem-parslet 1.5.0                                                                                                               
precise|main|amd64: rubygem-posix-spawn 0.3.9                                                                                                           
precise|main|amd64: rubygem-pygments.rb 0.6.0                                                                                                           
precise|main|amd64: rubygem-rb-fsevent 0.9.4                                                                                                            
precise|main|amd64: rubygem-rb-inotify 0.9.5                                                                                                            
precise|main|amd64: rubygem-redcarpet 3.2.0                                                                                                             
precise|main|amd64: rubygem-safe-yaml 1.0.4                                                                                                             
precise|main|amd64: rubygem-sass 3.4.6                                                                                                                  
precise|main|amd64: rubygem-timers 4.0.1                                                                                                                
precise|main|amd64: rubygem-toml 0.1.2                                                                                                                  
precise|main|amd64: rubygem-yajl-ruby 1.1.0 
```

So, now we can base robblog on this new dependency, configured in our own rosdep, added in https://github.com/strands-project/rosdistro/pull/85

This pull request adds this `run_depend` to make sure the package will be released with the dependency in place.
